### PR TITLE
fix: add explicit permissions to GitHub workflows

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -4,6 +4,11 @@ on:
     branches: [ 'main' ]
     types: [ 'opened', 'reopened', 'edited', 'synchronize' ]
 
+# Define explicit permissions following the principle of least privilege
+permissions:
+  pull-requests: read  # Needed to read PR information
+  contents: read       # Needed to checkout code
+
 jobs:
   check_pr_title:
     name: Check PR title

--- a/.github/workflows/pr-tests-coverage.yml
+++ b/.github/workflows/pr-tests-coverage.yml
@@ -2,6 +2,12 @@ name: PR Tests and Coverage
 
 on: pull_request
 
+# Define explicit permissions following the principle of least privilege
+permissions:
+  contents: read       # Needed to checkout code
+  pull-requests: read  # Needed to read PR information
+  security-events: write # Needed for SonarCloud analysis
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,12 @@ on:
       - "main"
       - "release/*"
 
+# Define explicit permissions following the principle of least privilege
+permissions:
+  contents: write  # Needed for creating releases and uploading artifacts
+  pull-requests: write  # Needed for release-please to create PRs
+  issues: read  # Basic read access to issues
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This PR adds explicit permissions to all GitHub workflow files following the principle of least privilege. This addresses security warnings related to workflows inheriting repository-level permissions which might be set to read-write by default.

### Changes

1. Added explicit permissions to `release-please.yml`:
   ```yaml
   permissions:
     contents: write      # Needed for creating releases and uploading artifacts
     pull-requests: write # Needed for release-please to create PRs
     issues: read         # Basic read access to issues
   ```

2. Added explicit permissions to `check-pr-title.yml`:
   ```yaml
   permissions:
     pull-requests: read  # Needed to read PR information
     contents: read       # Needed to checkout code
   ```

3. Added explicit permissions to `pr-tests-coverage.yml`:
   ```yaml
   permissions:
     contents: read       # Needed to checkout code
     pull-requests: read  # Needed to read PR information
     security-events: write # Needed for SonarCloud analysis
   ```

## Security Impact

These changes improve the security posture by following the principle of least privilege, ensuring each workflow has only the permissions it needs to operate.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author