### PR TITLE
chore: update GitHub Actions workflow to use GitHub App token for permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,12 +6,6 @@ on:
       - "main"
       - "release/*"
 
-# Define explicit permissions following the principle of least privilege
-permissions:
-  contents: write  # Needed for creating releases and uploading artifacts
-  pull-requests: write  # Needed for release-please to create PRs
-  issues: read  # Basic read access to issues
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -24,16 +18,26 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
         id: release
         with:
-          token: ${{ github.token }}
+          token: ${{ steps.generate-token.outputs.token }}
 
   upload-artifact:
     runs-on: ubuntu-latest
     needs: release
     if: ${{ needs.release.outputs.release_created }}
-
+    permissions:
+      contents: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2


### PR DESCRIPTION
- Removed explicit permissions section for the release job.
- Added a step to generate a GitHub App token with necessary permissions.
- Updated the release step to use the generated token for authentication.
- Ensured upload-artifact job retains write permissions for contents.

Scanned-by: gitleaks 8.30.0

https://linear.app/rudderstack/issue/INT-5644/use-github-app-instead-of-pat-for-repositories-using-release-please

**Fixes** # (*issue*)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
